### PR TITLE
Revamped output independent of stdio, markdown output and html output…

### DIFF
--- a/include/NadaJupyter.h
+++ b/include/NadaJupyter.h
@@ -1,0 +1,10 @@
+#ifndef NADA_JUPYTER_H
+#define NADA_JUPYTER_H
+
+#include "NadaValue.h"
+#include "NadaEnv.h"
+
+NadaValue *builtin_display_markdown(NadaValue *args, NadaEnv *env);
+NadaValue *builtin_display_html(NadaValue *args, NadaEnv *env);
+
+#endif  // NADA_JUPYTER_H

--- a/include/NadaOutput.h
+++ b/include/NadaOutput.h
@@ -1,0 +1,54 @@
+#ifndef NADA_OUTPUT_H
+#define NADA_OUTPUT_H
+
+#include <stdio.h>
+#include "NadaValue.h"
+
+typedef struct NadaOutputHandler NadaOutputHandler;
+
+// Output handler methods
+typedef void (*NadaOutputFn)(const char *str, void *user_data);
+typedef void (*NadaValueOutputFn)(NadaValue *val, void *user_data);
+
+struct NadaOutputHandler {
+    NadaOutputFn write;             // Write raw text
+    NadaValueOutputFn write_value;  // Write formatted value
+    void *user_data;                // Context for output functions
+};
+
+// Global output handler (default: stdout)
+extern NadaOutputHandler *nada_current_output;
+
+// Initialize default output handler
+void nada_output_init(void);
+
+// Clean up output handler
+void nada_output_cleanup(void);
+
+// Set custom output handler
+void nada_set_output_handler(NadaOutputHandler *handler);
+
+// Core output functions
+void nada_write_string(const char *str);
+void nada_write_format(const char *format, ...);
+void nada_write_value(NadaValue *val);
+
+// String conversion (returns newly allocated string)
+char *nada_value_to_string(NadaValue *val);
+
+// Output types
+typedef enum {
+    NADA_OUTPUT_TEXT = 0,
+    NADA_OUTPUT_MARKDOWN = 1,
+    NADA_OUTPUT_HTML = 2
+} NadaOutputType;
+
+// Set output mode for jupyter
+void nada_jupyter_set_output_type(NadaOutputType type);
+void nada_jupyter_init_buffer(void);
+const char *nada_jupyter_get_buffer(void);
+void nada_jupyter_clear_buffer(void);
+void nada_jupyter_use_output(void);
+void nada_jupyter_cleanup(void);
+
+#endif  // NADA_OUTPUT_H

--- a/include/NadaString.h
+++ b/include/NadaString.h
@@ -10,7 +10,7 @@ const char *utf8_index(const char *str, int index);
 int utf8_charlen(const char *str);
 
 // Convert a NadaValue to a string representation
-char *nada_value_to_string(NadaValue *val);
+// char *nada_value_to_string(NadaValue *val);
 
 // Exported string manipulation functions
 NadaValue *builtin_string_length(NadaValue *args, NadaEnv *env);

--- a/nadalib/CMakeLists.txt
+++ b/nadalib/CMakeLists.txt
@@ -17,6 +17,8 @@ set(LIB_SOURCES
     NadaBuiltinPredicates.c
     NadaBuiltinBoolOps.c
     NadaBuiltinIO.c
+    NadaOutput.c
+    NadaJupyter.c
 )
 
 # Add the library target

--- a/nadalib/NadaBuiltinIO.c
+++ b/nadalib/NadaBuiltinIO.c
@@ -7,6 +7,7 @@
 #include "NadaError.h"
 #include "NadaParser.h"
 #include "NadaBuiltinIO.h"
+#include "NadaOutput.h"
 
 // Built-in function: save-environment
 NadaValue *builtin_save_environment(NadaValue *args, NadaEnv *env) {
@@ -329,7 +330,7 @@ NadaValue *builtin_write_file(NadaValue *args, NadaEnv *env) {
 // display: Output a string to console without adding newlines
 NadaValue *builtin_display(NadaValue *args, NadaEnv *env) {
     if (nada_is_nil(args)) {
-        fprintf(stderr, "Error: display requires at least 1 argument\n");
+        nada_write_format("Error: display requires at least 1 argument\n");
         return nada_create_nil();
     }
 
@@ -338,44 +339,44 @@ NadaValue *builtin_display(NadaValue *args, NadaEnv *env) {
         NadaValue *val = nada_eval(nada_car(curr), env);
 
         if (val->type == NADA_STRING) {
-            // Process the string to handle escape sequences
+            // Process escape sequences
             const char *str = val->data.string;
             while (*str) {
                 if (*str == '\\' && *(str + 1) != '\0') {
                     // Handle escape sequences
                     switch (*(str + 1)) {
                     case 'n':
-                        printf("\n");
+                        nada_write_string("\n");
                         break;
                     case 't':
-                        printf("\t");
+                        nada_write_string("\t");
                         break;
                     case 'r':
-                        printf("\r");
+                        nada_write_string("\r");
                         break;
                     case '\\':
-                        printf("\\");
+                        nada_write_string("\\");
                         break;
                     case '"':
-                        printf("\"");
+                        nada_write_string("\"");
                         break;
                     default:
-                        printf("\\%c", *(str + 1));
+                        nada_write_format("\\%c", *(str + 1));
                         break;
                     }
                     str += 2;
                 } else {
-                    printf("%c", *str++);
+                    char tmp[2] = {*str++, '\0'};
+                    nada_write_string(tmp);
                 }
             }
         } else {
-            nada_print(val);  // Use regular printer for non-strings
+            nada_write_value(val);
         }
 
         nada_free(val);
         curr = nada_cdr(curr);
     }
 
-    // Remove the automatic newline at the end
     return nada_create_nil();
 }

--- a/nadalib/NadaEval.c
+++ b/nadalib/NadaEval.c
@@ -7,6 +7,7 @@
 #include "NadaParser.h"
 #include "NadaString.h"
 #include "NadaError.h"
+#include "NadaJupyter.h"
 
 // Forward declaration of the builtins array
 static BuiltinFuncInfo builtins[];
@@ -460,6 +461,8 @@ static BuiltinFuncInfo builtins[] = {
     {"read-file", builtin_read_file},
     {"write-file", builtin_write_file},
     {"display", builtin_display},
+    {"display-markdown", builtin_display_markdown},
+    {"display-html", builtin_display_html},
     {"read-line", builtin_read_line},
 
     // Evaluation

--- a/nadalib/NadaJupyter.c
+++ b/nadalib/NadaJupyter.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "NadaValue.h"
+#include "NadaEval.h"
+#include "NadaOutput.h"
+#include "NadaError.h"
+
+// Output markdown in Jupyter
+NadaValue *builtin_display_markdown(NadaValue *args, NadaEnv *env) {
+    if (nada_is_nil(args)) {
+        return nada_create_error("display-markdown requires at least 1 argument");
+    }
+
+    // Set output type to markdown
+    nada_jupyter_clear_buffer();  // Clear any previous output
+    nada_jupyter_set_output_type(NADA_OUTPUT_MARKDOWN);
+
+    // Process all arguments
+    NadaValue *curr = args;
+    while (!nada_is_nil(curr)) {
+        NadaValue *val = nada_eval(nada_car(curr), env);
+
+        // Convert to string if not already
+        if (val->type != NADA_STRING) {
+            char *str = nada_value_to_string(val);
+            nada_write_string(str);
+            free(str);
+        } else {
+            nada_write_string(val->data.string);
+        }
+
+        nada_free(val);
+        curr = nada_cdr(curr);
+
+        // Add space between arguments
+        if (!nada_is_nil(curr)) {
+            nada_write_string(" ");
+        }
+    }
+
+    return nada_create_nil();
+}
+
+// Output HTML in Jupyter
+NadaValue *builtin_display_html(NadaValue *args, NadaEnv *env) {
+    if (nada_is_nil(args)) {
+        return nada_create_error("display-html requires at least 1 argument");
+    }
+
+    // Set output type to HTML
+    nada_jupyter_clear_buffer();  // Clear any previous output
+    nada_jupyter_set_output_type(NADA_OUTPUT_HTML);
+
+    // Process all arguments
+    NadaValue *curr = args;
+    while (!nada_is_nil(curr)) {
+        NadaValue *val = nada_eval(nada_car(curr), env);
+
+        // Convert to string if not already
+        if (val->type != NADA_STRING) {
+            char *str = nada_value_to_string(val);
+            nada_write_string(str);
+            free(str);
+        } else {
+            nada_write_string(val->data.string);
+        }
+
+        nada_free(val);
+        curr = nada_cdr(curr);
+
+        // Add space between arguments
+        if (!nada_is_nil(curr)) {
+            nada_write_string(" ");
+        }
+    }
+
+    return nada_create_nil();
+}

--- a/nadalib/NadaOutput.c
+++ b/nadalib/NadaOutput.c
@@ -1,0 +1,237 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include "NadaOutput.h"
+#include "NadaEval.h"
+
+// Default stdout output handler
+static void default_write(const char *str, void *user_data) {
+    fputs(str, stdout);
+}
+
+static void default_write_value(NadaValue *val, void *user_data) {
+    // Format and print value to stdout
+    if (val == NULL) {
+        fputs("NULL", stdout);
+        return;
+    }
+
+    switch (val->type) {
+    case NADA_NUM: {
+        char *str = nada_num_to_string(val->data.number);
+        fputs(str, stdout);
+        free(str);
+        break;
+    }
+    case NADA_STRING:
+        fprintf(stdout, "\"%s\"", val->data.string);
+        break;
+    case NADA_SYMBOL:
+        fputs(val->data.symbol, stdout);
+        break;
+    case NADA_NIL:
+        fputs("()", stdout);
+        break;
+    case NADA_PAIR:
+        putc('(', stdout);
+        default_write_value(val->data.pair.car, NULL);
+
+        // Print rest of the list
+        NadaValue *rest = val->data.pair.cdr;
+        while (rest->type == NADA_PAIR) {
+            putc(' ', stdout);
+            default_write_value(rest->data.pair.car, NULL);
+            rest = rest->data.pair.cdr;
+        }
+
+        // Handle improper lists
+        if (rest->type != NADA_NIL) {
+            fputs(" . ", stdout);
+            default_write_value(rest, NULL);
+        }
+
+        putc(')', stdout);
+        break;
+    case NADA_FUNC:
+        if (val->data.function.builtin) {
+            const char *name = get_builtin_name(val->data.function.builtin);
+            if (name) {
+                fprintf(stdout, "#<builtin-function:%s>", name);
+            } else {
+                fputs("#<builtin-function>", stdout);
+            }
+        } else {
+            fputs("#<lambda ", stdout);
+            default_write_value(val->data.function.params, NULL);
+            putc('>', stdout);
+        }
+        break;
+    case NADA_BOOL:
+        fputs(val->data.boolean ? "#t" : "#f", stdout);
+        break;
+    case NADA_ERROR:
+        fprintf(stdout, "Error: %s", val->data.error);
+        break;
+    }
+}
+
+// Global output handler with default implementation
+static NadaOutputHandler default_handler = {
+    .write = default_write,
+    .write_value = default_write_value,
+    .user_data = NULL};
+
+NadaOutputHandler *nada_current_output = &default_handler;
+
+void nada_output_init(void) {
+    // Use default handler
+    nada_current_output = &default_handler;
+}
+
+void nada_output_cleanup(void) {
+    // Reset to default handler if needed
+    nada_current_output = &default_handler;
+}
+
+void nada_set_output_handler(NadaOutputHandler *handler) {
+    if (handler != NULL) {
+        nada_current_output = handler;
+    } else {
+        nada_current_output = &default_handler;
+    }
+}
+
+void nada_write_string(const char *str) {
+    if (nada_current_output && nada_current_output->write) {
+        nada_current_output->write(str, nada_current_output->user_data);
+    }
+}
+
+void nada_write_format(const char *format, ...) {
+    if (!nada_current_output || !nada_current_output->write)
+        return;
+
+    va_list args;
+    va_start(args, format);
+
+    // First determine buffer size
+    va_list args_copy;
+    va_copy(args_copy, args);
+    int size = vsnprintf(NULL, 0, format, args_copy) + 1;
+    va_end(args_copy);
+
+    char *buffer = malloc(size);
+    if (buffer) {
+        vsnprintf(buffer, size, format, args);
+        nada_current_output->write(buffer, nada_current_output->user_data);
+        free(buffer);
+    }
+
+    va_end(args);
+}
+
+void nada_write_value(NadaValue *val) {
+    if (nada_current_output && nada_current_output->write_value) {
+        nada_current_output->write_value(val, nada_current_output->user_data);
+    }
+}
+
+// Current output type for Jupyter
+static NadaOutputType jupyter_output_type = NADA_OUTPUT_TEXT;
+
+void nada_jupyter_set_output_type(NadaOutputType type) {
+    jupyter_output_type = type;
+}
+
+NadaOutputType nada_jupyter_get_output_type(void) {
+    return jupyter_output_type;
+}
+
+// Buffer for capturing Jupyter output
+typedef struct {
+    char *data;
+    size_t capacity;
+    size_t length;
+} JupyterBuffer;
+
+static JupyterBuffer jupyter_buffer = {NULL, 0, 0};
+
+// Initialize the Jupyter buffer
+void nada_jupyter_init_buffer(void) {
+    // Free previous buffer if exists
+    if (jupyter_buffer.data) {
+        free(jupyter_buffer.data);
+    }
+
+    // Allocate initial buffer
+    jupyter_buffer.capacity = 4096;
+    jupyter_buffer.data = malloc(jupyter_buffer.capacity);
+    jupyter_buffer.length = 0;
+
+    if (jupyter_buffer.data) {
+        jupyter_buffer.data[0] = '\0';
+    }
+}
+
+// Get the buffer content
+const char *nada_jupyter_get_buffer(void) {
+    return jupyter_buffer.data ? jupyter_buffer.data : "";
+}
+
+// Clear the Jupyter buffer
+void nada_jupyter_clear_buffer(void) {
+    if (jupyter_buffer.data) {
+        jupyter_buffer.data[0] = '\0';
+        jupyter_buffer.length = 0;
+    }
+    // Reset the output type as well
+    jupyter_output_type = NADA_OUTPUT_TEXT;
+}
+
+// Append to the Jupyter buffer
+static void jupyter_write(const char *str, void *user_data) {
+    if (!jupyter_buffer.data || !str) return;
+
+    size_t len = strlen(str);
+
+    // Ensure buffer has enough space
+    if (jupyter_buffer.length + len + 1 > jupyter_buffer.capacity) {
+        size_t new_capacity = jupyter_buffer.capacity * 2 + len;
+        char *new_buffer = realloc(jupyter_buffer.data, new_capacity);
+
+        if (!new_buffer) return;
+
+        jupyter_buffer.data = new_buffer;
+        jupyter_buffer.capacity = new_capacity;
+    }
+
+    // Append the string
+    strcpy(jupyter_buffer.data + jupyter_buffer.length, str);
+    jupyter_buffer.length += len;
+}
+
+// Custom output handler for Jupyter
+static NadaOutputHandler jupyter_handler = {
+    .write = jupyter_write,
+    .write_value = default_write_value,  // Reuse default formatter
+    .user_data = NULL};
+
+// Set up Jupyter output
+void nada_jupyter_use_output(void) {
+    nada_set_output_handler(&jupyter_handler);
+    nada_jupyter_init_buffer();
+    // Start with text output mode
+    jupyter_output_type = NADA_OUTPUT_TEXT;
+}
+
+// Free Jupyter buffer resources
+void nada_jupyter_cleanup(void) {
+    if (jupyter_buffer.data) {
+        free(jupyter_buffer.data);
+        jupyter_buffer.data = NULL;
+    }
+    jupyter_buffer.capacity = 0;
+    jupyter_buffer.length = 0;
+    jupyter_output_type = NADA_OUTPUT_TEXT;
+}

--- a/nadalib/NadaValue.c
+++ b/nadalib/NadaValue.c
@@ -1,8 +1,10 @@
-#include "NadaValue.h"
-#include "NadaEval.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+
+#include "NadaValue.h"
+#include "NadaEval.h"
+#include "NadaOutput.h"
 
 // Initialize counters
 static int value_allocations = 0;
@@ -233,70 +235,7 @@ void nada_free(NadaValue *val) {
 
 // Print a value (for debugging and REPL output)
 void nada_print(NadaValue *val) {
-    if (val == NULL) {
-        printf("NULL");
-        return;
-    }
-
-    switch (val->type) {
-    case NADA_NUM: {
-        char *str = nada_num_to_string(val->data.number);
-        printf("%s", str);
-        free(str);
-        break;
-    }
-    case NADA_STRING:
-        printf("\"%s\"", val->data.string);
-        break;
-    case NADA_SYMBOL:
-        printf("%s", val->data.symbol);
-        break;
-    case NADA_NIL:
-        printf("()");
-        break;
-    case NADA_PAIR:
-        printf("(");
-        nada_print(val->data.pair.car);
-
-        // Print rest of the list
-        NadaValue *rest = val->data.pair.cdr;
-        while (rest->type == NADA_PAIR) {
-            printf(" ");
-            nada_print(rest->data.pair.car);
-            rest = rest->data.pair.cdr;
-        }
-
-        // Handle improper lists
-        if (rest->type != NADA_NIL) {
-            printf(" . ");
-            nada_print(rest);
-        }
-
-        printf(")");
-        break;
-    case NADA_FUNC:
-        if (val->data.function.builtin) {
-            // For builtin functions, try to get the function name
-            const char *name = get_builtin_name(val->data.function.builtin);
-            if (name) {
-                printf("#<builtin-function:%s>", name);
-            } else {
-                printf("#<builtin-function>");
-            }
-        } else {
-            // For user-defined functions, show parameter info
-            printf("#<lambda ");
-            nada_print(val->data.function.params);
-            printf(">");
-        }
-        break;
-    case NADA_BOOL:
-        printf("%s", val->data.boolean ? "#t" : "#f");
-        break;
-    case NADA_ERROR:
-        printf("Error: %s", val->data.error);
-        break;
-    }
+    nada_write_value(val);
 }
 
 // Deep copy a value and all its children
@@ -369,24 +308,6 @@ int nada_is_error(const NadaValue *value) {
     return value->type == NADA_ERROR;
 }
 
-/*
-// Reverse a list in-place
-NadaValue *nada_reverse(NadaValue *list) {
-    NadaValue *result = nada_create_nil();
-
-    while (!nada_is_nil(list)) {
-        NadaValue *head = nada_car(list);
-        NadaValue *tail = nada_cdr(list);
-
-        result = nada_cons(head, result);
-        list = tail;
-    }
-
-    return result;
-}
-*/
-
-// Fix for nada_reverse function
 NadaValue *nada_reverse(NadaValue *list) {
     // Create a temporary variable for the nil value instead of passing directly
     NadaValue *result = nada_create_nil();

--- a/tests/run_lisp_tests.c
+++ b/tests/run_lisp_tests.c
@@ -9,6 +9,7 @@
 #include "NadaParser.h"
 #include "NadaValue.h"
 #include "NadaConfig.h"
+#include "NadaOutput.h"  // Include the new output header
 
 static NadaEnv *global_env = NULL;
 static int had_evaluation_error = 0;
@@ -19,11 +20,11 @@ static void test_error_handler(NadaErrorType type, const char *message, void *us
     // Do NOT error out if we are in silent mode, used for testing handling of undefined symbols
     if (!nada_is_global_silent_symbol_lookup()) {
         // Print the error message
-        fprintf(stderr, "Test-Handler-Error: %s\n", message);
+        nada_write_format("Test-Handler-Error: %s\n", message);
         // Set the flag to indicate an error occurred
         had_evaluation_error = 1;
     } else {
-        printf("Suppressing lookup-error: %s\n", message);
+        nada_write_format("Suppressing lookup-error: %s\n", message);
     }
 }
 
@@ -46,23 +47,24 @@ static int total_tests_run = 0;
 static int total_tests_passed = 0;
 
 static void report_results() {
+    // Empty implementation
 }
 
 // Run a single test file
 static int run_test_file(const char *filename) {
-    printf("Running tests from %s\n", filename);
+    nada_write_format("Running tests from %s\n", filename);
     // Load library files - similar to what we do in the REPL
     global_env = nada_create_standard_env();  // Change this to use standard env
 
-    printf("Loading libraries\n");
+    nada_write_string("Loading libraries\n");
     nada_load_libraries(global_env);
 
-    printf("Setting results boolean\n");
+    nada_write_string("Setting results boolean\n");
     // Add a global variable to track test results
     NadaValue *test_results_var = nada_create_bool(1);  // Start with true (all passed)
     nada_env_set(global_env, "tests-all-passed", test_results_var);
 
-    printf("Setting test count\n");
+    nada_write_string("Setting test count\n");
     // Add a counter for number of tests
     NadaValue *tests_run_var = nada_create_num_from_int(0);
     nada_env_set(global_env, "tests-run-count", tests_run_var);
@@ -76,11 +78,11 @@ static int run_test_file(const char *filename) {
     // Load and evaluate the file with additional error handling
     NadaValue *result = NULL;
 
-    printf("Loading file: %s\n", filename);
+    nada_write_format("Loading file: %s\n", filename);
     // Load and evaluate with careful error handling
     result = nada_load_file(filename, global_env);
 
-    printf("Getting test results\n");
+    nada_write_string("Getting test results\n");
     // Check for errors or test failures
     NadaValue *final_status = nada_env_get(global_env, "tests-all-passed", 1);  // Set silent flag
     int all_tests_passed = final_status && final_status->type == NADA_BOOL &&
@@ -122,23 +124,23 @@ static int run_test_file(const char *filename) {
 
     int success = !had_evaluation_error && result != NULL && all_tests_passed;
 
-    printf("Test file %s, test-count: %d\n", filename, file_tests);
+    nada_write_format("Test file %s, test-count: %d\n", filename, file_tests);
 
     // Update global counters correctly
     total_tests_run += file_tests;
     total_tests_passed += file_tests_passed;
 
     // Print file summary
-    printf("Ran %d tests from %s\n", file_tests, filename);
-    printf("  Passed: %d\n", file_tests_passed);
-    printf("  Failed: %d\n", file_tests_failed);
+    nada_write_format("Ran %d tests from %s\n", file_tests, filename);
+    nada_write_format("  Passed: %d\n", file_tests_passed);
+    nada_write_format("  Failed: %d\n", file_tests_failed);
 
     // Print overall summary
-    printf("\n==== Test Summary ====\n");
-    printf("Ran %d tests\n", total_tests_run);
-    printf("Passed: %d\n", total_tests_passed);
-    printf("Failed: %d\n", total_tests_run - total_tests_passed);
-    printf("========================\n");
+    nada_write_string("\n==== Test Summary ====\n");
+    nada_write_format("Ran %d tests\n", total_tests_run);
+    nada_write_format("Passed: %d\n", total_tests_passed);
+    nada_write_format("Failed: %d\n", total_tests_run - total_tests_passed);
+    nada_write_string("========================\n");
 
     // Clean up
     if (result) nada_free(result);
@@ -157,11 +159,11 @@ static void report_test_coverage(const char *dir_path) {
     // Open the directory
     dir = opendir(dir_path);
     if (!dir) {
-        fprintf(stderr, "Error: Could not open directory: %s\n", dir_path);
+        nada_write_format("Error: Could not open directory: %s\n", dir_path);
         return;
     }
 
-    printf("\n===== TEST COVERAGE REPORT =====\n");
+    nada_write_string("\n===== TEST COVERAGE REPORT =====\n");
 
     // Process each .scm file to count
     while ((entry = readdir(dir)) != NULL) {
@@ -177,7 +179,7 @@ static void report_test_coverage(const char *dir_path) {
 
     closedir(dir);
     // Print details of files
-    printf("Test files found: %d\n", total_files);
+    nada_write_format("Test files found: %d\n", total_files);
 }
 
 // Validate test file syntax
@@ -190,7 +192,7 @@ static void validate_test_file(const char *filename) {
     int define_test_count = 0;
     int assert_count = 0;
 
-    printf("Validating %s:\n", filename);
+    nada_write_format("Validating %s:\n", filename);
 
     while (fgets(line, sizeof(line), file)) {
         line_num++;
@@ -206,15 +208,18 @@ static void validate_test_file(const char *filename) {
         }
     }
 
-    printf("  Found %d tests with %d assertions\n",
-           define_test_count, assert_count);
+    nada_write_format("  Found %d tests with %d assertions\n",
+                      define_test_count, assert_count);
 
     fclose(file);
 }
 
 // Main function if running directly
 int main(int argc, char *argv[]) {
-    printf("=== NadaLisp Test Runner ===\n");
+    // Initialize output system
+    nada_output_init();
+
+    nada_write_string("=== NadaLisp Test Runner ===\n");
 
     // If a specific file is provided, just run that file
     if (argc > 1 && strstr(argv[1], ".scm")) {
@@ -226,9 +231,16 @@ int main(int argc, char *argv[]) {
         // Run the specific test file
         int result = run_test_file(argv[1]);
 
+        // Clean up output system
+        nada_output_cleanup();
+
         return result ? 0 : 1;
     } else {
-        printf("Usage: %s [test-file.scm]\n", argv[0]);
+        nada_write_format("Usage: %s [test-file.scm]\n", argv[0]);
+
+        // Clean up output system
+        nada_output_cleanup();
+
         return 1;
     }
 }


### PR DESCRIPTION
… for NadaLisp's jupyter kernel

- Output is now no longer fixed to stdio
- Rich clients (for now Jupyter) can display HTML or Markdown: `(display-html "html-string")` and `(display-markdown "markdown-including-latex-string")`.